### PR TITLE
Improved security

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stencila-desktop",
   "productName": "Stencila",
   "description": "Stencila for the desktop",
-  "version": "0.27.3",
+  "version": "0.27.4",
   "author": "Nokome Bentley",
   "homepage": "http://stenci.la",
   "repository": {

--- a/src/main.js
+++ b/src/main.js
@@ -6,10 +6,6 @@ const url = require('url')
 
 const { app, ipcMain, Menu } = electron // eslint-disable-line no-unused-vars
 
-// Run a Stencila Node.js host to provide execution contexts etc
-const { host } = require('stencila-node')
-host.start()
-
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow


### PR DESCRIPTION
The forthcoming 0.28 releases of the `stencila/node`, `stencila/r` and `stencila/py` packages have improved security for their embedded HTTP servers (tighter restrictions on cross-origin HTTP request and token based authorization by default).

This patch release improves security for the desktop application by removing the 0.27 version Node.js host. 

Users will still be able to run languages in external execution contexts e.g. R, Python, Node.js but will need to manually run a Stencila host from one of the language packages or by using the `stencila/docker` image. Because this version of the desktop still uses the 0.27 `stencila/stencila` code base, it does not send authentication cookies in requests to hosts. Thus, when using the 0.28 version language packages with this version of the desktop, users will need to turn off authorization (which is on by default) e.g.

```bash
Rscript -e 'stencila:::run(authorization=FALSE)'
```